### PR TITLE
Report errors when no column is found in MyPy output

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -31,7 +31,7 @@
     "issueMatchers": {
         "mypy": {
             "pattern": {
-                "regexp": "^(.*\\.py):([0-9]+):([0-9]+):\\s([a-z]+):\\s(.*)",
+                "regexp": "^(.*\\.py):(\\d+):(\\d+:)?\\s(\\w+):\\s(.*)",
                 "message": 5,
                 "code": 4,
                 "line": 2,


### PR DESCRIPTION
Fixes #2

Improve the pattern definition regexp to use character classes and make the column group optional.

Tested with the following output:
```
/Users/sdoran/python-files/typing-tests.py:17: error: Argument 1 to "my_other_func" has incompatible type "int"; expected "str"
/Users/sdoran/python-files/typing-tests.py:17:14 error: Argument 1 to "my_other_func" has incompatible type "int"; expected "str"
```