### PR TITLE
Do not try to remove a tmp path that does not exist

### DIFF
--- a/Scripts/provider.js
+++ b/Scripts/provider.js
@@ -108,7 +108,9 @@ class IssuesProvider {
 
             console.info("Found " + parser.issues.length + " issue(s)");
 
-            nova.fs.remove(tmpPath);
+            if (tmpPath) {
+                nova.fs.remove(tmpPath);
+            }
             resolve(parser.issues);
             parser.clear();
         });


### PR DESCRIPTION
Per discussion in https://github.com/Aeron/Mypy.novaextension/issues/2#issuecomment-1292032874, if the extension check mode is set to “On file change” this will crash the extension.

Co-authored-by: Guillaume Algis  <guillaume.algis+github@altmail.fr>