### PR TITLE
Expand executable path and emit error if it is missing

### DIFF
--- a/Scripts/provider.js
+++ b/Scripts/provider.js
@@ -10,7 +10,7 @@ class IssuesProvider {
     }
 
     async getProcess(filePath, tmpPath) {
-        const executablePath = this.config.get("executablePath");
+        const executablePath = nova.path.expanduser(this.config.get("executablePath"));
         const commandArguments = this.config.get("commandArguments");
         const pythonExecutablePath = this.config.get("pythonExecutablePath");
         let defaultOptions = [filePath];

--- a/Scripts/provider.js
+++ b/Scripts/provider.js
@@ -15,6 +15,11 @@ class IssuesProvider {
         const pythonExecutablePath = this.config.get("pythonExecutablePath");
         let defaultOptions = [filePath];
 
+        if (!nova.fs.stat(executablePath)) {
+            console.error(`Executable does not exist '${executablePath}'`)
+            return
+        }
+
         if (tmpPath) {
             defaultOptions.unshift("--shadow-file", "./" + filePath, tmpPath);
         }


### PR DESCRIPTION
There may be a better place to do this. This was just the obvious place where I already had access to the data. I'm pretty new to JavaScript and the Nova APIs.

Also mentioned in https://github.com/Aeron/Mypy.novaextension/issues/2#issuecomment-1292032874.